### PR TITLE
ci(tofu-ci): Add testing to workflow

### DIFF
--- a/.github/workflows/tofu-ci-reuse.yaml
+++ b/.github/workflows/tofu-ci-reuse.yaml
@@ -70,66 +70,48 @@ jobs:
           arg_lock: ${{ github.event_name == 'push' && 'true' || 'false' }}
 
       - name: Test idempotency
-        if: ${{ github.event_name == 'push' }}
         id: tf-plan-test
-        uses: devsectop/tf-via-pr@8ec105a049bb047a7ed5ee182c9548e2208dce86 # v11.1.0
-        with:
-          arg_chdir: ${{ inputs.tf-directory }}
-          arg_command: plan
-          #arg_detailed_exitcode: not if needed or what to set here
-          arg_lock: false
+        if: ${{ github.event_name == 'push' }}
+        env:
+          TF_IN_AUTOMATION: true
+        run: |
+          tofu -chdir=$GITHUB_WORKSPACE/${{ inputs.tf-directory }} plan -concise -compact-warnings -detailed-exitcode
+
+      - name: Test outcome
+        if: ${{ steps.tf-plan-test.outputs.exitcode != 0 }}
+        run: |
+          echo "### :heavy_exclamation_mark: OpenTofu plan produced a diff" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo ${{ steps.tf-plan-test.outputs.stdout }} >> $GITHUB_STEP_SUMMARY
+
+      - name: Test outcome
+        if: ${{ steps.tf-plan-test.outputs.exitcode == 0 }}
+        run: |
+          echo "### :white_check_mark: OpenTofu Plan ${{ steps.tf-plan-test.outcome }}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo ${{ steps.tf-plan-test.outputs.stdout }} >> $GITHUB_STEP_SUMMARY
 
       - name: Destroy
-        if: ${{ github.event_name == 'push' && inputs.destroy == 'true' }}
         id: tf-destroy
-        uses: devsectop/tf-via-pr@8ec105a049bb047a7ed5ee182c9548e2208dce86 # v11.1.0
-        with:
-          arg_chdir: ${{ inputs.tf-directory }}
-          arg_command: apply
-          arg_destroy: true
-          arg_lock: true
+        if: ${{ github.event_name == 'push' && inputs.destroy == 'true' }}
+        env:
+          TF_IN_AUTOMATION: true
+        run: |
+          tofu -chdir=$GITHUB_WORKSPACE/${{ inputs.tf-directory }} destroy -concise -compact-warnings -detailed-exitcode -lock=true tfplan
 
-      # - name: Test idempotency
-      #   id: tf-plan-test
-      #   if: ${{ github.event_name == 'push' }}
-      #   env:
-      #     TF_IN_AUTOMATION: true
-      #   run: |
-      #     cd $GITHUB_WORKSPACE/${{ inputs.tf-directory }} && tofu plan -concise -compact-warnings -detailed-exitcode
+      - name: Destroy summary
+        if: ${{ steps.tf-destroy.outputs.exitcode != 0 }}
+        run: |
+          echo "### :heavy_exclamation_mark: OpenTofu plan produced a diff" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo ${{ steps.tf-plan-test.outputs.stdout }} >> $GITHUB_STEP_SUMMARY
 
-      # - name: Test outcome
-      #   if: ${{ steps.tf-plan-test.outputs.exitcode != 0 }}
-      #   run: |
-      #     echo "### :heavy_exclamation_mark: OpenTofu plan produced a diff" >> $GITHUB_STEP_SUMMARY
-      #     echo "" >> $GITHUB_STEP_SUMMARY
-      #     echo ${{ steps.tf-plan-test.outputs.stdout }} >> $GITHUB_STEP_SUMMARY
-
-      # - name: Test outcome
-      #   if: ${{ steps.tf-plan-test.outputs.exitcode == 0 }}
-      #   run: |
-      #     echo "### :white_check_mark: OpenTofu Plan ${{ steps.tf-plan-test.outcome }}" >> $GITHUB_STEP_SUMMARY
-      #     echo "" >> $GITHUB_STEP_SUMMARY
-      #     echo ${{ steps.tf-plan-test.outputs.stdout }} >> $GITHUB_STEP_SUMMARY
-
-      # - name: Destroy
-      #   id: tf-destroy
-      #   if: ${{ github.event_name == 'push' && inputs.destroy == 'true' }}
-      #   run: |
-      #     cd $GITHUB_WORKSPACE/${{ inputs.tf-directory }} && tofu destroy -concise -compact-warnings -detailed-exitcode
-
-      # - name: Destroy outcome
-      #   if: ${{ steps.tf-destroy.outputs.exitcode != 0 }}
-      #   run: |
-      #     echo "### :heavy_exclamation_mark: OpenTofu plan produced a diff" >> $GITHUB_STEP_SUMMARY
-      #     echo "" >> $GITHUB_STEP_SUMMARY
-      #     echo ${{ steps.tf-plan-test.outputs.stdout }} >> $GITHUB_STEP_SUMMARY
-
-      # - name: Destroy outcome
-      #   if: ${{ steps.tf-destroy.outputs.exitcode == 0 }}
-      #   run: |
-      #     echo "### :white_check_mark: OpenTofu Plan ${{ steps.tf-plan-test.outcome }}" >> $GITHUB_STEP_SUMMARY
-      #     echo "" >> $GITHUB_STEP_SUMMARY
-      #     echo ${{ steps.tf-plan-test.outputs.stdout }} >> $GITHUB_STEP_SUMMARY
+      - name: Destroy summary
+        if: ${{ steps.tf-destroy.outputs.exitcode == 0 }}
+        run: |
+          echo "### :white_check_mark: OpenTofu Plan ${{ steps.tf-plan-test.outcome }}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo ${{ steps.tf-plan-test.outputs.stdout }} >> $GITHUB_STEP_SUMMARY
 
   #! Only works with terraform
   #TODO: Fork and update index.ts to use tofu instead

--- a/.github/workflows/tofu-ci-reuse.yaml
+++ b/.github/workflows/tofu-ci-reuse.yaml
@@ -11,6 +11,10 @@ on:
         description: Terraform / OpenTofu working directory
         required: true
         type: string
+      destroy:
+        description: true will destroy resources to check dependencies between modules
+        required: true
+        type: boolean
     secrets:
       backend-credentials:
         description: Credentials required to initialise the tf backend
@@ -64,6 +68,68 @@ jobs:
           arg_chdir: ${{ inputs.tf-directory }}
           arg_command: ${{ github.event_name == 'push' && 'apply' || 'plan' }}
           arg_lock: ${{ github.event_name == 'push' && 'true' || 'false' }}
+
+      - name: Test idempotency
+        if: ${{ github.event_name == 'push' }}
+        id: tf-plan-test
+        uses: devsectop/tf-via-pr@8ec105a049bb047a7ed5ee182c9548e2208dce86 # v11.1.0
+        with:
+          arg_chdir: ${{ inputs.tf-directory }}
+          arg_command: plan
+          #arg_detailed_exitcode: not if needed or what to set here
+          arg_lock: false
+
+      - name: Destroy
+        if: ${{ github.event_name == 'push' && inputs.destroy == 'true' }}
+        id: tf-destroy
+        uses: devsectop/tf-via-pr@8ec105a049bb047a7ed5ee182c9548e2208dce86 # v11.1.0
+        with:
+          arg_chdir: ${{ inputs.tf-directory }}
+          arg_command: apply
+          arg_destroy: true
+          arg_lock: true
+
+      # - name: Test idempotency
+      #   id: tf-plan-test
+      #   if: ${{ github.event_name == 'push' }}
+      #   env:
+      #     TF_IN_AUTOMATION: true
+      #   run: |
+      #     cd $GITHUB_WORKSPACE/${{ inputs.tf-directory }} && tofu plan -concise -compact-warnings -detailed-exitcode
+
+      # - name: Test outcome
+      #   if: ${{ steps.tf-plan-test.outputs.exitcode != 0 }}
+      #   run: |
+      #     echo "### :heavy_exclamation_mark: OpenTofu plan produced a diff" >> $GITHUB_STEP_SUMMARY
+      #     echo "" >> $GITHUB_STEP_SUMMARY
+      #     echo ${{ steps.tf-plan-test.outputs.stdout }} >> $GITHUB_STEP_SUMMARY
+
+      # - name: Test outcome
+      #   if: ${{ steps.tf-plan-test.outputs.exitcode == 0 }}
+      #   run: |
+      #     echo "### :white_check_mark: OpenTofu Plan ${{ steps.tf-plan-test.outcome }}" >> $GITHUB_STEP_SUMMARY
+      #     echo "" >> $GITHUB_STEP_SUMMARY
+      #     echo ${{ steps.tf-plan-test.outputs.stdout }} >> $GITHUB_STEP_SUMMARY
+
+      # - name: Destroy
+      #   id: tf-destroy
+      #   if: ${{ github.event_name == 'push' && inputs.destroy == 'true' }}
+      #   run: |
+      #     cd $GITHUB_WORKSPACE/${{ inputs.tf-directory }} && tofu destroy -concise -compact-warnings -detailed-exitcode
+
+      # - name: Destroy outcome
+      #   if: ${{ steps.tf-destroy.outputs.exitcode != 0 }}
+      #   run: |
+      #     echo "### :heavy_exclamation_mark: OpenTofu plan produced a diff" >> $GITHUB_STEP_SUMMARY
+      #     echo "" >> $GITHUB_STEP_SUMMARY
+      #     echo ${{ steps.tf-plan-test.outputs.stdout }} >> $GITHUB_STEP_SUMMARY
+
+      # - name: Destroy outcome
+      #   if: ${{ steps.tf-destroy.outputs.exitcode == 0 }}
+      #   run: |
+      #     echo "### :white_check_mark: OpenTofu Plan ${{ steps.tf-plan-test.outcome }}" >> $GITHUB_STEP_SUMMARY
+      #     echo "" >> $GITHUB_STEP_SUMMARY
+      #     echo ${{ steps.tf-plan-test.outputs.stdout }} >> $GITHUB_STEP_SUMMARY
 
   #! Only works with terraform
   #TODO: Fork and update index.ts to use tofu instead

--- a/.github/workflows/tofu-ci.yaml
+++ b/.github/workflows/tofu-ci.yaml
@@ -33,6 +33,7 @@ jobs:
     uses: ./.github/workflows/tofu-ci-reuse.yaml
     with:
       environment: development
+      destroy: false
       tf-directory: tf/dev/vpc
     secrets:
       backend-credentials: ${{ secrets.TF_TOKEN_APP_TERRAFORM_IO }}
@@ -40,27 +41,27 @@ jobs:
 
     #TODO Copy files from dev to prod
 
-  plan-and-apply-prd:
-    needs: [plan-and-apply-dev]
-    if: ${{ github.ref == 'refs/heads/main'}}
-    name: Open Tofu CI Production
-    permissions:
-      actions: read # Required to download repository artifact.
-      checks: write # Required to add status summary.
-      contents: read # Required to checkout repository.
-      id-token: write # Required to authenticate via OIDC.
-      pull-requests: write # Required to add PR comment and label.
-    uses: ./.github/workflows/tofu-ci-reuse.yaml
-    with:
-      environment: production
-      tf-directory: tf/prd/vpc
-    secrets:
-      backend-credentials: ${{ secrets.TF_TOKEN_APP_TERRAFORM_IO }}
-      provider-credentials: ${{ secrets.AWS_PRD_OIDC_ROLE_ARN }}
+  # plan-and-apply-prd:
+  #   needs: [plan-and-apply-dev]
+  #   if: ${{ github.ref == 'refs/heads/main'}}
+  #   name: Open Tofu CI Production
+  #   permissions:
+  #     actions: read # Required to download repository artifact.
+  #     checks: write # Required to add status summary.
+  #     contents: read # Required to checkout repository.
+  #     id-token: write # Required to authenticate via OIDC.
+  #     pull-requests: write # Required to add PR comment and label.
+  #   uses: ./.github/workflows/tofu-ci-reuse.yaml
+  #   with:
+  #     environment: production
+  #     tf-directory: tf/prd/vpc
+  #   secrets:
+  #     backend-credentials: ${{ secrets.TF_TOKEN_APP_TERRAFORM_IO }}
+  #     provider-credentials: ${{ secrets.AWS_PRD_OIDC_ROLE_ARN }}
 
-  terraform-docs:
-    if: ${{ github.event_name == 'push' }}
-    needs: [plan-and-apply-prd]
-    name: Terraform Docs
-    uses: 3ware/workflows/.github/workflows/terraform-docs.yaml@22e03ff8b79ce67f4a5059d0d24c3d07d8d69b1b # v4.2.2
-    secrets: inherit
+  # terraform-docs:
+  #   if: ${{ github.event_name == 'push' }}
+  #   needs: [plan-and-apply-prd]
+  #   name: Terraform Docs
+  #   uses: 3ware/workflows/.github/workflows/terraform-docs.yaml@22e03ff8b79ce67f4a5059d0d24c3d07d8d69b1b # v4.2.2
+  #   secrets: inherit

--- a/.github/workflows/tofu-ci.yaml
+++ b/.github/workflows/tofu-ci.yaml
@@ -2,18 +2,13 @@ name: OpenTofu CI
 
 on:
   pull_request:
-    types: [opened, synchronize]
     branches: [main]
-    paths:
-      - tf/**/*.tf
-      - tf/**/*.tfvars
+    paths: tf/**/*.{tf,tfvars}
   push:
     branches: [main]
-    paths:
-      - tf/**/*.tf
-      - tf/**/*.tfvars
+    paths: tf/**/*.{tf,tfvars}
 
-# Disable permissions for all available scopes
+# Disable permissions for all available scopes.
 permissions: {}
 
 concurrency:
@@ -24,52 +19,74 @@ jobs:
   find-terraform-dir:
     permissions:
       contents: read
-    uses: 3ware/workflows/.github/workflows/get-terraform-dir.yaml@57a900982a56bebaf91e660a56adb7f021690d15 # v4.0.0
+    uses: 3ware/workflows/.github/workflows/get-terraform-dir.yaml@0d6555cee0e14d49262dd42adb21bb077a188585 # v4.3.0
 
   plan-and-apply-dev:
     name: Open Tofu CI Development
     needs: [find-terraform-dir]
-    strategy:
-      matrix:
-        terraform-dir: ${{ fromJSON(needs.find-terraform-dir.outputs.terraform-dir) }}
+    runs-on: ubuntu-24.04
+
     permissions:
       actions: read # Required to download repository artifact.
       checks: write # Required to add status summary.
       contents: read # Required to checkout repository.
       id-token: write # Required to authenticate via OIDC.
       pull-requests: write # Required to add PR comment and label.
-    uses: ./.github/workflows/tofu-ci-reuse.yaml
-    with:
-      environment: development
-      destroy: false
-      tf-directory: ${{ matrix.terraform-dir }}
-    secrets:
-      backend-credentials: ${{ secrets.TF_TOKEN_APP_TERRAFORM_IO }}
-      provider-credentials: ${{ secrets.AWS_DEV_OIDC_ROLE_ARN }}
 
-    #TODO Copy files from dev to prod
+    strategy:
+      matrix:
+        terraform-dir: ${{ fromJSON(needs.find-terraform-dir.outputs.terraform-dir) }}
 
-  # plan-and-apply-prd:
-  #   needs: [plan-and-apply-dev]
-  #   if: ${{ github.ref == 'refs/heads/main'}}
-  #   name: Open Tofu CI Production
-  #   permissions:
-  #     actions: read # Required to download repository artifact.
-  #     checks: write # Required to add status summary.
-  #     contents: read # Required to checkout repository.
-  #     id-token: write # Required to authenticate via OIDC.
-  #     pull-requests: write # Required to add PR comment and label.
-  #   uses: ./.github/workflows/tofu-ci-reuse.yaml
-  #   with:
-  #     environment: production
-  #     tf-directory: tf/prd/vpc
-  #   secrets:
-  #     backend-credentials: ${{ secrets.TF_TOKEN_APP_TERRAFORM_IO }}
-  #     provider-credentials: ${{ secrets.AWS_PRD_OIDC_ROLE_ARN }}
+    env:
+      TF_TOKEN_APP_TERRAFORM_IO: ${{ secrets.TF_TOKEN_APP_TERRAFORM_IO }}
 
-  # terraform-docs:
-  #   if: ${{ github.event_name == 'push' }}
-  #   needs: [plan-and-apply-prd]
-  #   name: Terraform Docs
-  #   uses: 3ware/workflows/.github/workflows/terraform-docs.yaml@22e03ff8b79ce67f4a5059d0d24c3d07d8d69b1b # v4.2.2
-  #   secrets: inherit
+    # Set environment for push events only.
+    environment: ${{ github.event_name == 'push' && 'development' || '' }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
+      - name: Configure AWS credentials via OIDC
+        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
+        with:
+          aws-region: us-east-1
+          role-to-assume: ${{ secrets.AWS_DEV_OIDC_ROLE_ARN }}
+
+      - name: Setup OpenTofu
+        uses: opentofu/setup-opentofu@12f4debbf681675350b6cd1f0ff8ecfbda62027b # v1.0.4
+        with:
+          #TODO: Read version from providers.tf
+          tofu_version: 1.8.2
+          tofu_wrapper: true
+
+      - name: Provision infrastructure
+        uses: devsectop/tf-via-pr@86ff2b5756fb1c483c7c3ecc86f7c320c97a7302 # v11.4.1
+        with:
+          arg_chdir: ${{ matrix.terraform-dir }}
+          arg_command: ${{ github.event_name == 'push' && 'apply' || 'plan' }}
+          arg_lock: ${{ github.event_name == 'push' && 'true' || 'false' }}
+
+      - name: Check idempotency
+        id: idempotency
+        if: github.event_name == 'push'
+        uses: devsectop/tf-via-pr@86ff2b5756fb1c483c7c3ecc86f7c320c97a7302 # v11.4.1
+        with:
+          arg_chdir: ${{ matrix.terraform-dir }}
+          arg_command: plan
+          arg_lock: false
+          arg_detailed_exitcode: true
+
+      - name: Exit if idempotent
+        if: github.event_name == 'push' && steps.idempotency.outputs.exitcode != 0
+        shell: bash
+        run: exit ${{ steps.idempotency.outputs.exitcode }}
+
+      - name: Clean up resources
+        if: github.event_name == 'push'
+        uses: devsectop/tf-via-pr@86ff2b5756fb1c483c7c3ecc86f7c320c97a7302 # v11.4.1
+        with:
+          arg_chdir: ${{ matrix.terraform-dir }}
+          arg_command: destroy
+          arg_lock: true
+          arg_auto_approve: true

--- a/.github/workflows/tofu-ci.yaml
+++ b/.github/workflows/tofu-ci.yaml
@@ -21,9 +21,17 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  #TODO: Use find-terraform to get directory
+  find-terraform-dir:
+    permissions:
+      contents: read
+    uses: 3ware/workflows/.github/workflows/get-terraform-dir.yaml@57a900982a56bebaf91e660a56adb7f021690d15 # v4.0.0
+
   plan-and-apply-dev:
     name: Open Tofu CI Development
+    needs: [find-terraform-dir]
+    strategy:
+      matrix:
+        terraform-dir: ${{ fromJSON(needs.find-terraform-dir.outputs.terraform-dir) }}
     permissions:
       actions: read # Required to download repository artifact.
       checks: write # Required to add status summary.
@@ -34,7 +42,7 @@ jobs:
     with:
       environment: development
       destroy: false
-      tf-directory: tf/dev/vpc
+      tf-directory: ${{ matrix.terraform-dir }}
     secrets:
       backend-credentials: ${{ secrets.TF_TOKEN_APP_TERRAFORM_IO }}
       provider-credentials: ${{ secrets.AWS_DEV_OIDC_ROLE_ARN }}


### PR DESCRIPTION
When resources have been deployed in the dev environment, the plan should be run again to check for idempotencey.

The new plan should not produce a diff.

If the destroy input is set to true, then the resources should be destroyed to test dependancies.