### PR TITLE
ci(tofu-ci): Refactor the pipeline

### DIFF
--- a/.github/workflows/tofu-ci.yaml
+++ b/.github/workflows/tofu-ci.yaml
@@ -42,6 +42,8 @@ jobs:
           json: true
 
   trunk-check-tf:
+    # This job should only run in pull requests
+    if: github.event_name == 'pull_request'
     name: Trunk Check TF
     needs: [find-terraform]
     runs-on: ubuntu-latest
@@ -102,6 +104,12 @@ jobs:
   plan-and-apply-dev:
     name: Open Tofu CI Development
     needs: [find-terraform, trunk-check-tf]
+    # This job should run if trunk check succeeds in pull requests or is skipped on pushes
+    # always is required so this job isn't skipped when trunk check is skipped
+    if: |
+      always() &&
+      github.event_name == 'pull_request' && needs.trunk-check-tf.result == 'success' ||
+      github.event_name == 'push' && needs.trunk-check-tf.result == 'skipped'
     runs-on: ubuntu-latest
     permissions:
       actions: read # Required to download repository artifact.

--- a/tf/dev/vpc/main.tf
+++ b/tf/dev/vpc/main.tf
@@ -24,7 +24,7 @@ module "vpc" {
 
   create_igw             = true
   create_egress_only_igw = false
-  enable_nat_gateway     = true
+  enable_nat_gateway     = false
   single_nat_gateway     = false
   one_nat_gateway_per_az = true
 
@@ -132,7 +132,7 @@ resource "aws_key_pair" "a4l" {
 # trunk-ignore(trivy)
 # trunk-ignore(checkov)
 resource "aws_instance" "a4l_bastion" {
-  ami                         = "ami-033b95fb8079dc48"
+  ami                         = "ami-033b95fb8079dc481"
   instance_type               = "t2.micro"
   subnet_id                   = module.vpc.public_subnets[0]
   associate_public_ip_address = true


### PR DESCRIPTION
Add conditional expressions so that the trunk job only runs in pull requests, followed by the plan.

When merged only apply and post apply checks should run.