### PR TITLE
ci(terraform): Refactor test and deploy job to single job

### DIFF
--- a/.github/workflows/terraform-ci.yaml
+++ b/.github/workflows/terraform-ci.yaml
@@ -6,6 +6,7 @@ on:
     paths:
       - "**/*.tf"
       - "**/*.tfvars"
+      - "**/*.tftpl"
     branches: [main]
   merge_group:
     types: [checks_requested]
@@ -21,158 +22,9 @@ defaults:
     shell: bash
 
 jobs:
-  # test-terraform:
-  #   # This job should only run in pull requests
-  #   if: ${{ github.event_name == 'pull_request' }}
-  #   name: Test Terraform
-  #   runs-on: ubuntu-latest
-  #   permissions:
-  #     actions: read # Required to identify workflow run.
-  #     checks: write # Required to add status summary.
-  #     contents: read # Required to checkout repository.
-  #     id-token: write # Require for OIDC.
-  #     pull-requests: write # Required to add comment and label.
-  #   strategy:
-  #     matrix:
-  #       environment: ${{ fromJson(vars.ENVIRONMENTS) }}
-  #   environment: ${{ matrix.environment }}
-  #   steps:
-  #     - name: Checkout repository
-  #       uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-
-  #     # AWS Credentials required for tflint deep check
-  #     - name: Configure AWS credentials via OIDC
-  #       uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
-  #       with:
-  #         aws-region: us-east-1
-  #         mask-aws-account-id: true
-  #         role-to-assume: ${{ secrets[format('GHA_3WARE_OIDC_{0}', matrix.environment)] }}
-  #         role-session-name: tflint-deep-check-${{ matrix.environment }}
-
-  #     - name: Cache TFLint plugin directory
-  #       uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
-  #       with:
-  #         path: .trunk/plugins/
-  #         key: ${{ runner.os }}-${{ github.repository }}-tflint-${{ hashFiles('.trunk/configs/.tflint_ci.hcl') }}
-
-  #     # Run terraform format
-  #     - name: Terraform fmt
-  #       id: tf-fmt
-  #       run: terraform -chdir=terraform/${{ matrix.environment }}/vpc fmt -check
-  #       continue-on-error: true
-
-  #     # Initialise terraform in the directory where terraform file have changed.
-  #     - name: Initialise terraform
-  #       id: tf-init
-  #       run: |
-  #         terraform -chdir=terraform/${{ matrix.environment }}/vpc init -backend=false
-
-  #     # Run terraform validate
-  #     - name: Terraform validate
-  #       id: tf-validate
-  #       run: terraform -chdir=terraform/${{ matrix.environment }}/vpc validate -no-color
-  #       continue-on-error: true
-
-  #     # Add PR comment with formatting and validation errors
-  #     - name: Add PR comment on terraform failure
-  #       if: ${{ steps.tf-fmt.outputs.exitcode != 0 || steps.tf-validate.outputs.exitcode != 0 }}
-  #       uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31 # v2.9.0
-  #       with:
-  #         header: test
-  #         hide_and_recreate: true
-  #         message: |
-  #           #### ${{ matrix.environment }}
-
-  #           #### :x: Terraform Format and Style ${{ steps.tf-fmt.outcome }}
-
-  #           ${{ steps.tf-fmt.outputs.stdout }}
-
-  #           #### :x: Terraform Validation ${{ steps.tf-validate.outcome }}
-
-  #           ```
-  #           ${{ steps.tf-validate.outputs.stderr }}
-  #           ```
-
-  #           Resolve these issues and commit your changes to trigger another deployment.
-
-  #     # Exit this workflow if fmt or validate fail
-  #     - name: Terraform error
-  #       if: ${{ steps.tf-fmt.outputs.exitcode != 0 || steps.tf-validate.outputs.exitcode != 0 }}
-  #       run: |
-  #         exit 1
-
-  #     # Install TFLint; required to download plugins
-  #     - name: Install TFLint
-  #       uses: terraform-linters/setup-tflint@15ef44638cb215296e7ba9e7a41f20b5b06f4784 # v4.0.0
-  #       with:
-  #         tflint_version: v0.53.0
-  #         tflint_wrapper: true
-
-  #     # Initialise TFLint using the configuration file in the trunk directory
-  #     - name: Initialise TFLint
-  #       shell: bash
-  #       run: |
-  #         tflint -chdir=terraform/${{ matrix.environment }}/vpc --init --config=$GITHUB_WORKSPACE/.trunk/configs/.tflint_ci.hcl
-
-  #     - name: Run TFLint
-  #       id: tflint
-  #       run: |
-  #         tflint -chdir=terraform/${{ matrix.environment }}/vpc --config=$GITHUB_WORKSPACE/.trunk/configs/.tflint_ci.hcl --format compact
-  #       continue-on-error: true
-
-  #     # Add PR comment when TFLint detects a violation
-  #     - name: Add PR comment on TFLint failure
-  #       if: ${{ steps.tflint.outputs.exitcode != 0 }}
-  #       uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31 # v2.9.0
-  #       with:
-  #         header: test
-  #         hide_and_recreate: true
-  #         message: |
-  #           #### ${{ matrix.environment }}
-
-  #           #### :x: TFLint failure
-
-  #           ```
-  #           ${{ steps.tflint.outputs.stdout }}
-  #           ```
-
-  #           Resolve these issues and commit your changes to trigger another deployment.
-
-  #     # Exit workflow if TFLint detects a violation
-  #     - name: TFLint error
-  #       if: ${{ steps.tflint.outputs.exitcode != 0 }}
-  #       run: |
-  #         exit 1
-
-  #     # Run Trunk Check without terraform and tflint due to deep check issue
-  #     - name: Trunk Check
-  #       uses: trunk-io/trunk-action@2eaee169140ec559bd556208f9f99cdfdf468da8 # v1.1.17
-  #       with:
-  #         arguments: --filter checkov,trivy
-
-  #     - name: Update PR comment for Test success
-  #       uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31 # v2.9.0
-  #       with:
-  #         header: test
-  #         hide_and_recreate: true
-  #         message: |
-  #           #### ${{ matrix.environment }}
-
-  #           #### :white_check_mark: Terraform Format and Style ${{ steps.tf-fmt.outcome }}
-  #           #### :white_check_mark: Terraform Validation ${{ steps.tf-validate.outcome }}
-  #           #### :white_check_mark: TFLint ${{ steps.tf-validate.outcome }}
-
-  deploy:
-    name: Terraform Deploy
+  terraform-ci:
+    name: Terraform CI
     runs-on: ubuntu-latest
-    # needs: [test-terraform]
-    # This job should run `terraform plan` following the successful completion of trunk-check-tf
-    # `terraform apply` is triggered when the PR is merged. trunk-check-tf does not run on merge,
-    # so this job should run when test-terraform is skipped
-    # if: |
-    #   always() &&
-    #   github.event_name == 'pull_request' && needs.test-terraform.result == 'success' ||
-    #   github.event_name == 'merge_group' && needs.test-terraform.result == 'skipped'
     permissions:
       actions: read # Required to identify workflow run.
       checks: write # Required to add status summary.
@@ -184,20 +36,143 @@ jobs:
       max-parallel: 1
       matrix:
         environment: ${{ fromJson(vars.ENVIRONMENTS) }}
+    environment: ${{ matrix.environment }}
     env:
       TF_TOKEN_APP_TERRAFORM_IO: ${{ secrets.TF_TOKEN_APP_TERRAFORM_IO }}
-    environment: ${{ matrix.environment }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
+      # AWS Credentials required for tflint deep check
       - name: Configure AWS credentials via OIDC
         uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
         with:
           aws-region: us-east-1
           mask-aws-account-id: true
           role-to-assume: ${{ secrets[format('GHA_3WARE_OIDC_{0}', matrix.environment)] }}
-          role-session-name: aws-net-sec-${{ matrix.environment }}-terraform-deploy
+          role-session-name: ${{ github.event_name == 'merge_group' && 'aws-net-sec-terraform-apply' || 'aws-net-sec-terraform-plan' }}
+
+      - name: Cache TFLint plugin directory
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+        with:
+          path: .trunk/plugins/
+          key: ${{ runner.os }}-${{ github.repository }}-tflint-${{ hashFiles('.trunk/configs/.tflint_ci.hcl') }}
+
+      # Run terraform format
+      - name: Terraform fmt
+        if: ${{ github.event_name == 'pull_request' }}
+        id: tf-fmt
+        run: terraform -chdir=terraform/${{ matrix.environment }}/vpc fmt -check
+        continue-on-error: true
+
+      # Initialise terraform in the directory where terraform file have changed.
+      - name: Initialise terraform
+        if: ${{ github.event_name == 'pull_request' }}
+        id: tf-init
+        run: |
+          terraform -chdir=terraform/${{ matrix.environment }}/vpc init -backend=false
+
+      # Run terraform validate
+      - name: Terraform validate
+        if: ${{ github.event_name == 'pull_request' }}
+        id: tf-validate
+        run: terraform -chdir=terraform/${{ matrix.environment }}/vpc validate -no-color
+        continue-on-error: true
+
+      # Add PR comment with formatting and validation errors
+      - name: Add PR comment on terraform failure
+        if: ${{ steps.tf-fmt.outputs.exitcode != 0 || steps.tf-validate.outputs.exitcode != 0 }}
+        uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31 # v2.9.0
+        with:
+          header: test
+          hide_and_recreate: true
+          message: |
+            #### ${{ matrix.environment }}
+
+            #### :x: Terraform Format and Style ${{ steps.tf-fmt.outcome }}
+
+            ${{ steps.tf-fmt.outputs.stdout }}
+
+            #### :x: Terraform Validation ${{ steps.tf-validate.outcome }}
+
+            ```
+            ${{ steps.tf-validate.outputs.stderr }}
+            ```
+
+            Resolve these issues and commit your changes to trigger another deployment.
+
+      # Exit this workflow if fmt or validate fail
+      - name: Terraform error
+        if: ${{ steps.tf-fmt.outputs.exitcode != 0 || steps.tf-validate.outputs.exitcode != 0 }}
+        run: |
+          exit 1
+
+      # Install TFLint; required to download plugins
+      - name: Install TFLint
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: terraform-linters/setup-tflint@15ef44638cb215296e7ba9e7a41f20b5b06f4784 # v4.0.0
+        with:
+          tflint_version: v0.53.0
+          tflint_wrapper: true
+
+      # Initialise TFLint using the configuration file in the trunk directory
+      - name: Initialise TFLint
+        if: ${{ github.event_name == 'pull_request' }}
+        shell: bash
+        run: |
+          tflint -chdir=terraform/${{ matrix.environment }}/vpc --init --config=$GITHUB_WORKSPACE/.trunk/configs/.tflint_ci.hcl
+
+      - name: Run TFLint
+        if: ${{ github.event_name == 'pull_request' }}
+        id: tflint
+        run: |
+          tflint -chdir=terraform/${{ matrix.environment }}/vpc --config=$GITHUB_WORKSPACE/.trunk/configs/.tflint_ci.hcl --format compact
+        continue-on-error: true
+
+      # Add PR comment when TFLint detects a violation
+      - name: Add PR comment on TFLint failure
+        if: ${{ steps.tflint.outputs.exitcode != 0 }}
+        uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31 # v2.9.0
+        with:
+          header: test
+          hide_and_recreate: true
+          message: |
+            #### ${{ matrix.environment }}
+
+            #### :x: TFLint failure
+
+            ```
+            ${{ steps.tflint.outputs.stdout }}
+            ```
+
+            Resolve these issues and commit your changes to trigger another deployment.
+
+      # Exit workflow if TFLint detects a violation
+      - name: TFLint error
+        if: ${{ steps.tflint.outputs.exitcode != 0 }}
+        run: |
+          exit 1
+
+      # Run Trunk Check without terraform and tflint due to deep check issue
+      - name: Trunk Check
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: trunk-io/trunk-action@2eaee169140ec559bd556208f9f99cdfdf468da8 # v1.1.17
+        with:
+          arguments: --filter checkov,trivy
+
+      - name: Update PR comment for Test success
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31 # v2.9.0
+        with:
+          header: test
+          hide_and_recreate: true
+          message: |
+            #### ${{ matrix.environment }}
+
+            #### :white_check_mark: Terraform Format and Style ${{ steps.tf-fmt.outcome }}
+            #### :white_check_mark: Terraform Validation ${{ steps.tf-validate.outcome }}
+            #### :white_check_mark: TFLint ${{ steps.tf-validate.outcome }}
 
       - name: Provision TF
         uses: devsectop/tf-via-pr@f1acaae1d94826457fa57bc65f1df318fd81b3bc # v12.0.0

--- a/.github/workflows/terraform-ci.yaml
+++ b/.github/workflows/terraform-ci.yaml
@@ -183,7 +183,7 @@ jobs:
       fail-fast: true
       max-parallel: 1
       matrix:
-        environment: [development, production]
+        environment: ${{ fromJson(vars.ENVIRONMENTS) }}
     env:
       TF_TOKEN_APP_TERRAFORM_IO: ${{ secrets.TF_TOKEN_APP_TERRAFORM_IO }}
     environment: ${{ matrix.environment }}

--- a/.github/workflows/terraform-ci.yaml
+++ b/.github/workflows/terraform-ci.yaml
@@ -181,3 +181,4 @@ jobs:
           arg-lock: ${{ github.event_name == 'merge_group' }}
           working-directory: terraform/${{ matrix.environment }}/vpc
           plan-encrypt: ${{ secrets.PGP_SECRET_SIGNING_PASSPHRASE }}
+          comment-pr: recreate

--- a/.github/workflows/terraform-ci.yaml
+++ b/.github/workflows/terraform-ci.yaml
@@ -162,7 +162,7 @@ jobs:
             #### :white_check_mark: Terraform Validation ${{ steps.tf-validate.outcome }}
             #### :white_check_mark: TFLint ${{ steps.tf-validate.outcome }}
 
-  plan-and-apply:
+  deploy:
     name: Terraform Deploy
     runs-on: ubuntu-latest
     needs: [test-terraform]
@@ -183,7 +183,7 @@ jobs:
       fail-fast: true
       max-parallel: 1
       matrix:
-        environment: ${{ fromJson(vars.ENVIRONMENTS) }}
+        environment: [development, production]
     env:
       TF_TOKEN_APP_TERRAFORM_IO: ${{ secrets.TF_TOKEN_APP_TERRAFORM_IO }}
     environment: ${{ matrix.environment }}

--- a/.github/workflows/terraform-ci.yaml
+++ b/.github/workflows/terraform-ci.yaml
@@ -21,158 +21,158 @@ defaults:
     shell: bash
 
 jobs:
-  test-terraform:
-    # This job should only run in pull requests
-    if: ${{ github.event_name == 'pull_request' }}
-    name: Test Terraform
-    runs-on: ubuntu-latest
-    permissions:
-      actions: read # Required to identify workflow run.
-      checks: write # Required to add status summary.
-      contents: read # Required to checkout repository.
-      id-token: write # Require for OIDC.
-      pull-requests: write # Required to add comment and label.
-    strategy:
-      matrix:
-        environment: ${{ fromJson(vars.ENVIRONMENTS) }}
-    environment: ${{ matrix.environment }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+  # test-terraform:
+  #   # This job should only run in pull requests
+  #   if: ${{ github.event_name == 'pull_request' }}
+  #   name: Test Terraform
+  #   runs-on: ubuntu-latest
+  #   permissions:
+  #     actions: read # Required to identify workflow run.
+  #     checks: write # Required to add status summary.
+  #     contents: read # Required to checkout repository.
+  #     id-token: write # Require for OIDC.
+  #     pull-requests: write # Required to add comment and label.
+  #   strategy:
+  #     matrix:
+  #       environment: ${{ fromJson(vars.ENVIRONMENTS) }}
+  #   environment: ${{ matrix.environment }}
+  #   steps:
+  #     - name: Checkout repository
+  #       uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
-      # AWS Credentials required for tflint deep check
-      - name: Configure AWS credentials via OIDC
-        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
-        with:
-          aws-region: us-east-1
-          mask-aws-account-id: true
-          role-to-assume: ${{ secrets[format('GHA_3WARE_OIDC_{0}', matrix.environment)] }}
-          role-session-name: tflint-deep-check-${{ matrix.environment }}
+  #     # AWS Credentials required for tflint deep check
+  #     - name: Configure AWS credentials via OIDC
+  #       uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
+  #       with:
+  #         aws-region: us-east-1
+  #         mask-aws-account-id: true
+  #         role-to-assume: ${{ secrets[format('GHA_3WARE_OIDC_{0}', matrix.environment)] }}
+  #         role-session-name: tflint-deep-check-${{ matrix.environment }}
 
-      - name: Cache TFLint plugin directory
-        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
-        with:
-          path: .trunk/plugins/
-          key: ${{ runner.os }}-${{ github.repository }}-tflint-${{ hashFiles('.trunk/configs/.tflint_ci.hcl') }}
+  #     - name: Cache TFLint plugin directory
+  #       uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+  #       with:
+  #         path: .trunk/plugins/
+  #         key: ${{ runner.os }}-${{ github.repository }}-tflint-${{ hashFiles('.trunk/configs/.tflint_ci.hcl') }}
 
-      # Run terraform format
-      - name: Terraform fmt
-        id: tf-fmt
-        run: terraform -chdir=terraform/${{ matrix.environment }}/vpc fmt -check
-        continue-on-error: true
+  #     # Run terraform format
+  #     - name: Terraform fmt
+  #       id: tf-fmt
+  #       run: terraform -chdir=terraform/${{ matrix.environment }}/vpc fmt -check
+  #       continue-on-error: true
 
-      # Initialise terraform in the directory where terraform file have changed.
-      - name: Initialise terraform
-        id: tf-init
-        run: |
-          terraform -chdir=terraform/${{ matrix.environment }}/vpc init -backend=false
+  #     # Initialise terraform in the directory where terraform file have changed.
+  #     - name: Initialise terraform
+  #       id: tf-init
+  #       run: |
+  #         terraform -chdir=terraform/${{ matrix.environment }}/vpc init -backend=false
 
-      # Run terraform validate
-      - name: Terraform validate
-        id: tf-validate
-        run: terraform -chdir=terraform/${{ matrix.environment }}/vpc validate -no-color
-        continue-on-error: true
+  #     # Run terraform validate
+  #     - name: Terraform validate
+  #       id: tf-validate
+  #       run: terraform -chdir=terraform/${{ matrix.environment }}/vpc validate -no-color
+  #       continue-on-error: true
 
-      # Add PR comment with formatting and validation errors
-      - name: Add PR comment on terraform failure
-        if: ${{ steps.tf-fmt.outputs.exitcode != 0 || steps.tf-validate.outputs.exitcode != 0 }}
-        uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31 # v2.9.0
-        with:
-          header: test
-          hide_and_recreate: true
-          message: |
-            #### ${{ matrix.environment }}
+  #     # Add PR comment with formatting and validation errors
+  #     - name: Add PR comment on terraform failure
+  #       if: ${{ steps.tf-fmt.outputs.exitcode != 0 || steps.tf-validate.outputs.exitcode != 0 }}
+  #       uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31 # v2.9.0
+  #       with:
+  #         header: test
+  #         hide_and_recreate: true
+  #         message: |
+  #           #### ${{ matrix.environment }}
 
-            #### :x: Terraform Format and Style ${{ steps.tf-fmt.outcome }}
+  #           #### :x: Terraform Format and Style ${{ steps.tf-fmt.outcome }}
 
-            ${{ steps.tf-fmt.outputs.stdout }}
+  #           ${{ steps.tf-fmt.outputs.stdout }}
 
-            #### :x: Terraform Validation ${{ steps.tf-validate.outcome }}
+  #           #### :x: Terraform Validation ${{ steps.tf-validate.outcome }}
 
-            ```
-            ${{ steps.tf-validate.outputs.stderr }}
-            ```
+  #           ```
+  #           ${{ steps.tf-validate.outputs.stderr }}
+  #           ```
 
-            Resolve these issues and commit your changes to trigger another deployment.
+  #           Resolve these issues and commit your changes to trigger another deployment.
 
-      # Exit this workflow if fmt or validate fail
-      - name: Terraform error
-        if: ${{ steps.tf-fmt.outputs.exitcode != 0 || steps.tf-validate.outputs.exitcode != 0 }}
-        run: |
-          exit 1
+  #     # Exit this workflow if fmt or validate fail
+  #     - name: Terraform error
+  #       if: ${{ steps.tf-fmt.outputs.exitcode != 0 || steps.tf-validate.outputs.exitcode != 0 }}
+  #       run: |
+  #         exit 1
 
-      # Install TFLint; required to download plugins
-      - name: Install TFLint
-        uses: terraform-linters/setup-tflint@15ef44638cb215296e7ba9e7a41f20b5b06f4784 # v4.0.0
-        with:
-          tflint_version: v0.53.0
-          tflint_wrapper: true
+  #     # Install TFLint; required to download plugins
+  #     - name: Install TFLint
+  #       uses: terraform-linters/setup-tflint@15ef44638cb215296e7ba9e7a41f20b5b06f4784 # v4.0.0
+  #       with:
+  #         tflint_version: v0.53.0
+  #         tflint_wrapper: true
 
-      # Initialise TFLint using the configuration file in the trunk directory
-      - name: Initialise TFLint
-        shell: bash
-        run: |
-          tflint -chdir=terraform/${{ matrix.environment }}/vpc --init --config=$GITHUB_WORKSPACE/.trunk/configs/.tflint_ci.hcl
+  #     # Initialise TFLint using the configuration file in the trunk directory
+  #     - name: Initialise TFLint
+  #       shell: bash
+  #       run: |
+  #         tflint -chdir=terraform/${{ matrix.environment }}/vpc --init --config=$GITHUB_WORKSPACE/.trunk/configs/.tflint_ci.hcl
 
-      - name: Run TFLint
-        id: tflint
-        run: |
-          tflint -chdir=terraform/${{ matrix.environment }}/vpc --config=$GITHUB_WORKSPACE/.trunk/configs/.tflint_ci.hcl --format compact
-        continue-on-error: true
+  #     - name: Run TFLint
+  #       id: tflint
+  #       run: |
+  #         tflint -chdir=terraform/${{ matrix.environment }}/vpc --config=$GITHUB_WORKSPACE/.trunk/configs/.tflint_ci.hcl --format compact
+  #       continue-on-error: true
 
-      # Add PR comment when TFLint detects a violation
-      - name: Add PR comment on TFLint failure
-        if: ${{ steps.tflint.outputs.exitcode != 0 }}
-        uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31 # v2.9.0
-        with:
-          header: test
-          hide_and_recreate: true
-          message: |
-            #### ${{ matrix.environment }}
+  #     # Add PR comment when TFLint detects a violation
+  #     - name: Add PR comment on TFLint failure
+  #       if: ${{ steps.tflint.outputs.exitcode != 0 }}
+  #       uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31 # v2.9.0
+  #       with:
+  #         header: test
+  #         hide_and_recreate: true
+  #         message: |
+  #           #### ${{ matrix.environment }}
 
-            #### :x: TFLint failure
+  #           #### :x: TFLint failure
 
-            ```
-            ${{ steps.tflint.outputs.stdout }}
-            ```
+  #           ```
+  #           ${{ steps.tflint.outputs.stdout }}
+  #           ```
 
-            Resolve these issues and commit your changes to trigger another deployment.
+  #           Resolve these issues and commit your changes to trigger another deployment.
 
-      # Exit workflow if TFLint detects a violation
-      - name: TFLint error
-        if: ${{ steps.tflint.outputs.exitcode != 0 }}
-        run: |
-          exit 1
+  #     # Exit workflow if TFLint detects a violation
+  #     - name: TFLint error
+  #       if: ${{ steps.tflint.outputs.exitcode != 0 }}
+  #       run: |
+  #         exit 1
 
-      # Run Trunk Check without terraform and tflint due to deep check issue
-      - name: Trunk Check
-        uses: trunk-io/trunk-action@2eaee169140ec559bd556208f9f99cdfdf468da8 # v1.1.17
-        with:
-          arguments: --filter checkov,trivy
+  #     # Run Trunk Check without terraform and tflint due to deep check issue
+  #     - name: Trunk Check
+  #       uses: trunk-io/trunk-action@2eaee169140ec559bd556208f9f99cdfdf468da8 # v1.1.17
+  #       with:
+  #         arguments: --filter checkov,trivy
 
-      - name: Update PR comment for Test success
-        uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31 # v2.9.0
-        with:
-          header: test
-          hide_and_recreate: true
-          message: |
-            #### ${{ matrix.environment }}
+  #     - name: Update PR comment for Test success
+  #       uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31 # v2.9.0
+  #       with:
+  #         header: test
+  #         hide_and_recreate: true
+  #         message: |
+  #           #### ${{ matrix.environment }}
 
-            #### :white_check_mark: Terraform Format and Style ${{ steps.tf-fmt.outcome }}
-            #### :white_check_mark: Terraform Validation ${{ steps.tf-validate.outcome }}
-            #### :white_check_mark: TFLint ${{ steps.tf-validate.outcome }}
+  #           #### :white_check_mark: Terraform Format and Style ${{ steps.tf-fmt.outcome }}
+  #           #### :white_check_mark: Terraform Validation ${{ steps.tf-validate.outcome }}
+  #           #### :white_check_mark: TFLint ${{ steps.tf-validate.outcome }}
 
   deploy:
     name: Terraform Deploy
     runs-on: ubuntu-latest
-    needs: [test-terraform]
+    # needs: [test-terraform]
     # This job should run `terraform plan` following the successful completion of trunk-check-tf
     # `terraform apply` is triggered when the PR is merged. trunk-check-tf does not run on merge,
     # so this job should run when test-terraform is skipped
-    if: |
-      always() &&
-      github.event_name == 'pull_request' && needs.test-terraform.result == 'success' ||
-      github.event_name == 'merge_group' && needs.test-terraform.result == 'skipped'
+    # if: |
+    #   always() &&
+    #   github.event_name == 'pull_request' && needs.test-terraform.result == 'success' ||
+    #   github.event_name == 'merge_group' && needs.test-terraform.result == 'skipped'
     permissions:
       actions: read # Required to identify workflow run.
       checks: write # Required to add status summary.

--- a/.github/workflows/terraform-ci.yaml
+++ b/.github/workflows/terraform-ci.yaml
@@ -117,7 +117,7 @@ jobs:
       - name: Run TFLint
         id: tflint
         run: |
-          tflint --config=$GITHUB_WORKSPACE/.trunk/configs/.tflint_ci.hcl --format compact
+          tflint -chdir=terraform/${{ matrix.environment }}/vpc --config=$GITHUB_WORKSPACE/.trunk/configs/.tflint_ci.hcl --format compact
         continue-on-error: true
 
       # Add PR comment when TFLint detects a violation


### PR DESCRIPTION
Having two jobs and the matrix was causing problems with TF-via-PR action. See workflow run log:

https://github.com/3ware/aws-network-speciality/actions/runs/11574975232/job/32220876724

Screenshot of the error:

<img width="722" alt="Screenshot 2024-10-29 at 14 49 32" src="https://github.com/user-attachments/assets/97888a60-76c2-43a1-bf96-25b28fec9db1">

I'll raise this with the maintainer at some point, but for now the workflow runs as a singled job. 

This has additional benefits:

- Less duplication of code: permissions, matrix, checkout, aws
- Dev runs all the way to plan before you need to approve prod. Before the test workflow had to be approved in prod before the dev plan would run.