### PR TITLE
ci(terraform): Streamline and integrate TFLint within existing PR comment

### DIFF
--- a/.github/workflows/terraform-ci.yaml
+++ b/.github/workflows/terraform-ci.yaml
@@ -84,7 +84,7 @@ jobs:
       - name: Terraform Fmt + Init + Validate
         if: ${{ github.event_name == 'pull_request' }}
         id: tf
-        uses: devsectop/tf-via-pr@9dfb2360a5b7d5c3385276221e6e372467199e46 # v12.0.3
+        uses: devsectop/tf-via-pr@a917bd222a6a780f25d2c5cd1942f6b2c2f16a7a # v12.0.5
         with:
           working-directory: ${{ matrix.targets }}
           arg-lock: false
@@ -143,7 +143,7 @@ jobs:
           exit 1
 
       - name: Terraform ${{ format('{0}', github.event_name == 'merge_group' && 'Apply' || 'Plan') }}
-        uses: devsectop/tf-via-pr@9dfb2360a5b7d5c3385276221e6e372467199e46 # v12.0.3
+        uses: devsectop/tf-via-pr@a917bd222a6a780f25d2c5cd1942f6b2c2f16a7a # v12.0.5
         with:
           working-directory: ${{ matrix.targets }}
           command: ${{ github.event_name == 'merge_group' && 'apply' || 'plan' }}

--- a/.github/workflows/terraform-ci.yaml
+++ b/.github/workflows/terraform-ci.yaml
@@ -65,14 +65,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          fetch-depth: 0
           persist-credentials: false
 
-      # This is required because the 'environment' context does not exist, do cannot be referenced
-      # my the steps that need it
+      # This is required because the 'environment' context does not exist, so cannot be referenced
+      # by the steps that need it
       - name: Set deployment environment as an environment variable
-        run: |
-          echo "ENVIRONMENT=${{ contains(matrix.targets, 'production') && 'production' || 'development' }}" >> $GITHUB_ENV
+        run: echo "ENVIRONMENT=${{ contains(matrix.targets, 'production') && 'production' || 'development' }}" >> $GITHUB_ENV
 
       # AWS Credentials required for tflint deep check
       - name: Configure AWS credentials via OIDC
@@ -83,61 +81,22 @@ jobs:
           role-to-assume: ${{ secrets[format('GHA_3WARE_OIDC_{0}', env.ENVIRONMENT)] }}
           role-session-name: ${{ github.event_name == 'merge_group' && 'aws-net-sec-terraform-apply' || 'aws-net-sec-terraform-plan' }}
 
+      - name: Terraform Fmt + Init + Validate
+        if: ${{ github.event_name == 'pull_request' }}
+        id: tf
+        uses: devsectop/tf-via-pr@9dfb2360a5b7d5c3385276221e6e372467199e46 # v12.0.3
+        with:
+          working-directory: ${{ matrix.targets }}
+          arg-lock: false
+          format: true
+          validate: true
+
       - name: Cache TFLint plugin directory
         if: ${{ github.event_name == 'pull_request' }}
         uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
         with:
           path: .trunk/plugins/
           key: ${{ runner.os }}-${{ github.repository }}-tflint-${{ hashFiles('.trunk/configs/.tflint_ci.hcl') }}
-
-      # Run terraform format
-      - name: Terraform fmt
-        if: ${{ github.event_name == 'pull_request' }}
-        id: tf-fmt
-        run: terraform -chdir=${{ matrix.targets }} fmt -check
-        continue-on-error: true
-
-      # Initialise terraform in the directory where terraform file have changed.
-      - name: Initialise terraform
-        if: ${{ github.event_name == 'pull_request' }}
-        id: tf-init
-        run: |
-          terraform -chdir=${{ matrix.targets }} init -backend=false
-
-      # Run terraform validate
-      - name: Terraform validate
-        if: ${{ github.event_name == 'pull_request' }}
-        id: tf-validate
-        run: terraform -chdir=${{ matrix.targets }} validate -no-color
-        continue-on-error: true
-
-      # Add PR comment with formatting and validation errors
-      - name: Add PR comment on terraform failure
-        if: ${{ steps.tf-fmt.outputs.exitcode != 0 || steps.tf-validate.outputs.exitcode != 0 }}
-        uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31 # v2.9.0
-        with:
-          header: test-${{ matrix.targets }}
-          recreate: true
-          message: |
-            #### ${{ matrix.targets }}
-
-            #### :x: Terraform Format and Style ${{ steps.tf-fmt.outcome }}
-
-            ${{ steps.tf-fmt.outputs.stdout }}
-
-            #### :x: Terraform Validation ${{ steps.tf-validate.outcome }}
-
-            ```
-            ${{ steps.tf-validate.outputs.stderr }}
-            ```
-
-            Resolve these issues and commit your changes to trigger another deployment.
-
-      # Exit this workflow if fmt or validate fail
-      - name: Terraform error
-        if: ${{ steps.tf-fmt.outputs.exitcode != 0 || steps.tf-validate.outputs.exitcode != 0 }}
-        run: |
-          exit 1
 
       # Install TFLint; required to download plugins
       - name: Install TFLint
@@ -147,62 +106,46 @@ jobs:
           tflint_version: v0.53.0
           tflint_wrapper: true
 
-      # Initialise TFLint using the configuration file in the trunk directory
-      - name: Initialise TFLint
-        if: ${{ github.event_name == 'pull_request' }}
-        shell: bash
-        run: |
-          tflint -chdir=${{ matrix.targets }} --init --config=$GITHUB_WORKSPACE/.trunk/configs/.tflint_ci.hcl
-
+      # Run TFLint using the configuration file in the trunk directory
       - name: Run TFLint
         if: ${{ github.event_name == 'pull_request' }}
         id: tflint
         run: |
+          tflint -chdir=${{ matrix.targets }} --config=$GITHUB_WORKSPACE/.trunk/configs/.tflint_ci.hcl --init
           tflint -chdir=${{ matrix.targets }} --config=$GITHUB_WORKSPACE/.trunk/configs/.tflint_ci.hcl --format compact
         continue-on-error: true
 
-      # Add PR comment when TFLint detects a violation
-      - name: Add PR comment on TFLint failure
+      # Add PR comment then exit workflow if TFLint detects a violation
+      - name: Add PR comment on TFLint error
         if: ${{ steps.tflint.outputs.exitcode != 0 }}
-        uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31 # v2.9.0
-        with:
-          header: test-${{ matrix.targets }}
-          recreate: true
-          message: |
-            #### ${{ matrix.targets }}
-
-            #### :x: TFLint failure
-
-            ```
-            ${{ steps.tflint.outputs.stdout }}
-            ```
-
-            Resolve these issues and commit your changes to trigger another deployment.
-
-      # Exit workflow if TFLint detects a violation
-      - name: TFLint error
-        if: ${{ steps.tflint.outputs.exitcode != 0 }}
+        env:
+          GH_TOKEN: ${{ github.token }} # https://cli.github.com/manual/gh_auth_login
         run: |
+          # Compose TFLint output.
+          tflint="
+          <details><summary>❌ TFLint error.</summary>
+
+          \`\`\`hcl
+          ${{ steps.tflint.outputs.stderr || steps.tflint.outputs.stdout }}
+          \`\`\`
+          </details>"
+
+          # Get body of PR comment from tf step output.
+          comment=$(gh api /repos/{owner}/{repo}/issues/comments/${{ steps.tf.outputs.comment-id }} --method GET --jq '.body')
+
+          # Replace placeholder with TFLint output.
+          comment=$(echo $comment | sed "s|<!-- placeholder-2 -->|$tflint|")
+
+          # Update PR comment combined with TFLint output.
+          gh api /repos/{owner}/{repo}/issues/comments/${{ steps.tf.outputs.comment-id }} --method PATCH --field body="$comment"
+
+          # Exit workflow due to TFLint error.
           exit 1
 
-      - name: Update PR comment for Test success
-        if: ${{ github.event_name == 'pull_request' }}
-        uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31 # v2.9.0
+      - name: Terraform ${{ format('{0}', github.event_name == 'merge_group' && 'Apply' || 'Plan') }}
+        uses: devsectop/tf-via-pr@9dfb2360a5b7d5c3385276221e6e372467199e46 # v12.0.3
         with:
-          header: test-${{ matrix.targets }}
-          recreate: true
-          message: |
-            #### ${{ matrix.targets }}
-
-            #### :white_check_mark: Terraform Format and Style ${{ steps.tf-fmt.outcome }}
-            #### :white_check_mark: Terraform Validation ${{ steps.tf-validate.outcome }}
-            #### :white_check_mark: TFLint ${{ steps.tf-validate.outcome }}
-
-      - name: Provision TF
-        uses: devsectop/tf-via-pr@f1acaae1d94826457fa57bc65f1df318fd81b3bc # v12.0.0
-        with:
+          working-directory: ${{ matrix.targets }}
           command: ${{ github.event_name == 'merge_group' && 'apply' || 'plan' }}
           arg-lock: ${{ github.event_name == 'merge_group' }}
-          working-directory: ${{ matrix.targets }}
           plan-encrypt: ${{ secrets.PGP_SECRET_SIGNING_PASSPHRASE }}
-          comment-pr: recreate

--- a/.github/workflows/terraform-ci.yaml
+++ b/.github/workflows/terraform-ci.yaml
@@ -134,7 +134,7 @@ jobs:
           comment=$(gh api /repos/{owner}/{repo}/issues/comments/${{ steps.tf.outputs.comment-id }} --method GET --jq '.body')
 
           # Replace placeholder with TFLint output.
-          comment=$(echo $comment | sed "s|<!-- placeholder-2 -->|$tflint|")
+          comment=$(echo "$comment" | sed "s|<!-- placeholder-2 -->|$tflint|")
 
           # Update PR comment combined with TFLint output.
           gh api /repos/{owner}/{repo}/issues/comments/${{ steps.tf.outputs.comment-id }} --method PATCH --field body="$comment"

--- a/terraform/development/vpc/versions.tf
+++ b/terraform/development/vpc/versions.tf
@@ -1,6 +1,6 @@
 terraform {
   # Must be above 1.9.0 to allow cross-object referencing for input variable validations
-  required_version = ">=1.9.0, < 2.0.0"
+  required_version = ">=1.9.0, <2.0.0"
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/terraform/development/vpc/versions.tf
+++ b/terraform/development/vpc/versions.tf
@@ -1,6 +1,6 @@
 terraform {
   # Must be above 1.9.0 to allow cross-object referencing for input variable validations
-  required_version = ">=1.9.0, <2.0.0"
+  required_version = ">=1.9.0, < 2.0.0"
   required_providers {
     aws = {
       source  = "hashicorp/aws"


### PR DESCRIPTION
Tweaks to consolidate some steps together to streamline the workflow and better integrate TFLint error output (if present) within existing PR comment.

- L68: Removed `fetch-depth: 0` from "terraform-deploy" job as it is not required (unlike "targets" job).
- L93-L141: Consolidated Terraform `fmt`, `init`, and `validate` steps together > PR comment on success/failure > exit on failure.
- L150-L162: Merged TFLint `init` and `format` steps together.
- L164-L199: Integrated TFLint error output within existing PR comment > update-in-place to keep on top of PR conversation > exit on failure. Skip altogether if TFLint is successful.
- L288: Reuse existing PR comment for plan/apply output to retain [revision history](https://github.com/DevSecTop/TF-via-PR#:~:text=through%20the%20comment%27s-,revision%20history,-.).

... ain't no way the workflow works-as-expected first time 'round—feel free to amend as required!