### PR TITLE
ci(terraform): Change workflow trigger to run on PR closure

### DIFF
--- a/.github/workflows/terraform-docs.yaml
+++ b/.github/workflows/terraform-docs.yaml
@@ -1,22 +1,22 @@
 name: Terraform Docs
-run-name: ${{ github.event.workflow_run.display_title }}
 
 on:
-  workflow_run:
-    workflows: [Terraform CI]
-    types: [completed]
+  pull_request:
+    types: [closed]
+    branches: [main]
+    paths:
+      - terraform/**/*.tf
+      - terraform/**/*.tfvars
+      - terraform/**/*.tftpl
 
 # Disable permissions for all available scopes
 permissions: {}
 
 jobs:
   terraform-docs:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event.pull_request.merged == true }}
     name: Terraform Docs
     uses: 3ware/workflows/.github/workflows/terraform-docs.yaml@7880d6b986d1d689f5d219e901b863f1378fea9c # v4.4.0
     secrets: inherit
-    strategy:
-      matrix:
-        environment: ${{ fromJson(vars.ENVIRONMENTS) }}
     with:
-      tf-directory: terraform/${{ matrix.environment }}/vpc
+      tf-directory: terraform


### PR DESCRIPTION
terraform-docs workflow should run when a PR, containing terraform file changes, is successfully merged. 