### PR TITLE
ci(terraform): prevent pointless pr label during initialization

### DIFF
--- a/.github/workflows/terraform-ci.yaml
+++ b/.github/workflows/terraform-ci.yaml
@@ -135,7 +135,7 @@ jobs:
           comment=$(gh api /repos/{owner}/{repo}/issues/comments/${{ steps.tf.outputs.comment-id }} --method GET --jq '.body')
 
           # Replace placeholder with TFLint output.
-          comment=$(echo "$comment" | sed "s|<!-- placeholder-2 -->|$tflint|")
+          comment=$(echo "$comment" | sed "s|<!-- placeholder-2 -->|$tflint|g")
 
           # Update PR comment combined with TFLint output.
           gh api /repos/{owner}/{repo}/issues/comments/${{ steps.tf.outputs.comment-id }} --method PATCH --field body="$comment"

--- a/.github/workflows/terraform-ci.yaml
+++ b/.github/workflows/terraform-ci.yaml
@@ -90,6 +90,7 @@ jobs:
           arg-lock: false
           format: true
           validate: true
+          label-pr: false
 
       - name: Cache TFLint plugin directory
         if: ${{ github.event_name == 'pull_request' }}


### PR DESCRIPTION
Tweak to prevent pointless `tf:` PR label during TF initialization step.

EDIT: Also add delimiter to sed.