### PR TITLE
ci(terraform): amend string substitution method with bash equivalent

### DIFF
--- a/.github/workflows/terraform-ci.yaml
+++ b/.github/workflows/terraform-ci.yaml
@@ -135,7 +135,7 @@ jobs:
           comment=$(gh api /repos/{owner}/{repo}/issues/comments/${{ steps.tf.outputs.comment-id }} --method GET --jq '.body')
 
           # Replace placeholder with TFLint output.
-          comment=$(echo "$comment" | sed "s|<!-- placeholder-2 -->|$tflint|g")
+          comment="${comment//<!-- placeholder-2 -->/$tflint}"
 
           # Update PR comment combined with TFLint output.
           gh api /repos/{owner}/{repo}/issues/comments/${{ steps.tf.outputs.comment-id }} --method PATCH --field body="$comment"


### PR DESCRIPTION
Fix up bash string substitution.