### PR TITLE
ci(pr-check): Update dependency-review action to v4.18.0

### DIFF
--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -24,7 +24,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    uses: 3ware/workflows/.github/workflows/dependency-review.yaml@2f8001ae2c31dc22bac309ac1cc309d4cde3dff4 # v4.16.0
+    uses: 3ware/workflows/.github/workflows/dependency-review.yaml@f469ee8612f15ec29656e569eb6c2b53f44b243e # v4.18.0
 
   enforce-all-checks:
     name: Checks


### PR DESCRIPTION
New version does not add empty sections to the PR comment.
