### PR TITLE
feat(dev): Add local provider configuration for testing

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -28,6 +28,7 @@
         "release",
         "stg",
         "terraform-docs",
+        "tflint",
         "trunk",
         "uat",
         "vpc",

--- a/.github/workflows/iac-deploy.yaml
+++ b/.github/workflows/iac-deploy.yaml
@@ -19,7 +19,7 @@ jobs:
       contents: read
       id-token: write
       pull-requests: write
-    uses: 3ware/workflows/.github/workflows/iac-deploy.yaml@feat-iac-deploy
+    uses: 3ware/workflows/.github/workflows/iac-deploy.yaml@742f0f5c35c5038dc3ab7df9f942f762f320d6b2 # v4.1.9
     secrets: inherit
     with:
       environment: development

--- a/.gitignore
+++ b/.gitignore
@@ -9,13 +9,12 @@
 crash.log
 crash.*.log
 
-# Exclude all .tfvars files, which are likely to contain sentitive data, such as
+# Exclude all .tfvars files, which are likely to contain sensitive data, such as
 # password, private keys, and other secrets. These should not be part of version
 # control as they are data points which are potentially sensitive and subject
 # to change depending on the environment.
-#
-#terraform.tfvars
-terraform/vpc/terraform.tfvars
+# *.tfvars
+# *.tfvars.json
 
 # Ignore override files as they are usually used to override resources locally and so
 # are not checked in
@@ -24,8 +23,10 @@ override.tf.json
 *_override.tf
 *_override.tf.json
 
+# Ignore transient lock info files created by terraform apply
+.terraform.tfstate.lock.info
+
 # Include override files you do wish to add to version control using negated pattern
-#
 # !example_override.tf
 
 # Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
@@ -35,6 +36,5 @@ override.tf.json
 .terraformrc
 terraform.rc
 
-# Exclude pem files used for authentication
-*.pem
+# Ignore local environment variables
 .envrc

--- a/iac/environments/dev/main.tf
+++ b/iac/environments/dev/main.tf
@@ -22,9 +22,6 @@ terraform {
 
 provider "aws" {
   region = var.aws_region
-  # Use the 3ware-org profile locally. TF_VAR_isLocal is set in the .envrc file
-  # A role will be assumed using the aws-configure-credentials action in CI
-  profile = var.is_local == true ? "3ware-org" : null
 
   default_tags {
     tags = {

--- a/iac/environments/dev/variables.tf
+++ b/iac/environments/dev/variables.tf
@@ -17,9 +17,3 @@ variable "aws_service" {
   description = "(Required) The AWS service being deployed"
   type        = string
 }
-
-variable "is_local" {
-  description = "(Optional) Is this a local environment? `true` sets the provider profile for credentials. `false` does not."
-  type        = bool
-  default     = false
-}


### PR DESCRIPTION
When `is_Local` is set to true, a `dynamic_block` will add the role to assume in the aws provider configuration. This allows tf commands to be run locally for testing prior to creating a PR. In CI, the `is_Local` variables defaults to `false` so the profile and role are omitted from the provider config. `aws-configure-credentials` is used to assume the role from the Github Actions runner.