### PR TITLE
fix(dev): Update AWS provider version to 5.91

### DIFF
--- a/iac/environments/dev/main.tf
+++ b/iac/environments/dev/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.90"
+      version = "~> 5.91"
     }
   }
 


### PR DESCRIPTION
Auto-merge has been enabled so renovate can auto-merge it's PRs using the merge queue. Currently they are failing.

This PR has been created to ensure that PRs of this nature - iac deployment PRs - are not auto-merged.